### PR TITLE
Fix for #12

### DIFF
--- a/custom_components/syncthru/config_flow.py
+++ b/custom_components/syncthru/config_flow.py
@@ -30,9 +30,9 @@ class SyncThruConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return await self._async_show_form(step_id="user")
         return await self._async_check_and_create("user", user_input)
 
-    async def async_step_ssdp(self, discovery_info: ssdp.SsdpServiceInfo) -> FlowResult:
+    async def async_step_ssdp(self, discovery_info: homeassistant.helpers.service_info.ssdp.SsdpServiceInfo) -> FlowResult:
         """Handle SSDP initiated flow."""
-        await self.async_set_unique_id(discovery_info.upnp[ssdp.ATTR_UPNP_UDN])
+        await self.async_set_unique_id(discovery_info.upnp[homeassistant.helpers.service_info.ssdp.ATTR_UPNP_UDN])
         self._abort_if_unique_id_configured()
 
         self.url = url_normalize(
@@ -48,7 +48,7 @@ class SyncThruConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             # Update unique id of entry with the same URL
             if not existing_entry.unique_id:
                 self.hass.config_entries.async_update_entry(
-                    existing_entry, unique_id=discovery_info.upnp[ssdp.ATTR_UPNP_UDN]
+                    existing_entry, unique_id=discovery_info.upnp[homeassistant.helpers.service_info.ssdp.ATTR_UPNP_UDN]
                 )
             return self.async_abort(reason="already_configured")
 

--- a/custom_components/syncthru/config_flow.py
+++ b/custom_components/syncthru/config_flow.py
@@ -12,6 +12,12 @@ from homeassistant.components import ssdp
 from homeassistant.const import CONF_NAME, CONF_URL
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import aiohttp_client
+from homeassistant.helpers.service_info.ssdp import (
+    ATTR_UPNP_FRIENDLY_NAME,
+    ATTR_UPNP_PRESENTATION_URL,
+    ATTR_UPNP_UDN,
+    SsdpServiceInfo,
+)
 
 from .const import DEFAULT_MODEL, DEFAULT_NAME_TEMPLATE, DOMAIN
 
@@ -30,9 +36,9 @@ class SyncThruConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return await self._async_show_form(step_id="user")
         return await self._async_check_and_create("user", user_input)
 
-    async def async_step_ssdp(self, discovery_info: homeassistant.helpers.service_info.ssdp.SsdpServiceInfo) -> FlowResult:
+    async def async_step_ssdp(self, discovery_info: SsdpServiceInfo) -> FlowResult:
         """Handle SSDP initiated flow."""
-        await self.async_set_unique_id(discovery_info.upnp[homeassistant.helpers.service_info.ssdp.ATTR_UPNP_UDN])
+        await self.async_set_unique_id(discovery_info.upnp[ATTR_UPNP_UDN])
         self._abort_if_unique_id_configured()
 
         self.url = url_normalize(
@@ -48,7 +54,7 @@ class SyncThruConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             # Update unique id of entry with the same URL
             if not existing_entry.unique_id:
                 self.hass.config_entries.async_update_entry(
-                    existing_entry, unique_id=discovery_info.upnp[homeassistant.helpers.service_info.ssdp.ATTR_UPNP_UDN]
+                    existing_entry, unique_id=discovery_info.upnp[ATTR_UPNP_UDN]
                 )
             return self.async_abort(reason="already_configured")
 


### PR DESCRIPTION
Fixes the following warning in the logs:
```
Logger: homeassistant.components.ssdp
Source: helpers/deprecation.py:222
integration: Simple Service Discovery Protocol (SSDP) (documentation, issues)
First occurred: 2:19:37 PM (5 occurrences)
Last logged: 2:19:43 PM

SsdpServiceInfo was used from syncthru, this is a deprecated constant which will be removed in HA Core 2026.2. Use homeassistant.helpers.service_info.ssdp.SsdpServiceInfo instead, please report it to the author of the 'syncthru' custom integration
ATTR_UPNP_UDN was used from syncthru, this is a deprecated constant which will be removed in HA Core 2026.2. Use homeassistant.helpers.service_info.ssdp.ATTR_UPNP_UDN instead, please report it to the author of the 'syncthru' custom integration
```